### PR TITLE
Add parsing for trailing return types

### DIFF
--- a/clang/include/clang/AST/StmtCXX.h
+++ b/clang/include/clang/AST/StmtCXX.h
@@ -18,6 +18,7 @@
 #include "clang/AST/NestedNameSpecifier.h"
 #include "clang/AST/Stmt.h"
 #include "clang/Lex/Token.h"
+#include "clang/Sema/Ownership.h"
 #include "llvm/Support/Compiler.h"
 
 namespace clang {
@@ -1011,6 +1012,9 @@ class InspectStmt final : public Stmt,
   // True if this is a constexpr inspect
   bool ConstexprInspect;
 
+  /// Trailing return type for this inspect
+  TypeResult TrailingReturnType;
+
   // InspectStmt is followed by several trailing objects,
   // some of which optional. Note that it would be more convenient to
   // put the optional trailing objects at the end but this would change
@@ -1044,7 +1048,7 @@ class InspectStmt final : public Stmt,
 
   /// Build an inspect statement.
   InspectStmt(const ASTContext &Ctx, Stmt *Init, VarDecl *Var, Expr *Cond,
-              bool IsConstexpr);
+              bool IsConstexpr, TypeResult ReturnType);
 
   /// Build an empty inspect statement.
   explicit InspectStmt(EmptyShell Empty, bool HasInit, bool HasVar);
@@ -1052,7 +1056,8 @@ class InspectStmt final : public Stmt,
 public:
   /// Create an inspect statement.
   static InspectStmt *Create(const ASTContext &Ctx, Stmt *Init, VarDecl *Var,
-                             Expr *Cond, bool IsConstexpr);
+                             Expr *Cond, bool IsConstexpr,
+                             TypeResult ReturnType);
 
   /// Create an empty inspect statement optionally with storage for
   /// an init expression and a condition variable.
@@ -1170,6 +1175,8 @@ public:
   }
 
   bool isConstexpr() const { return ConstexprInspect; }
+
+  TypeResult getTrailingReturnType() const { return TrailingReturnType; }
 
   // Iterators
   child_range children() {

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -4222,7 +4222,8 @@ public:
   StmtResult ActOnFinishSwitchStmt(SourceLocation SwitchLoc,
                                            Stmt *Switch, Stmt *Body);
   StmtResult ActOnStartOfInspectStmt(SourceLocation InspectLoc, Stmt *InitStmt,
-                                     ConditionResult Cond, bool IsConstexpr);
+                                     ConditionResult Cond, bool IsConstexpr,
+                                     TypeResult ReturnType);
   StmtResult ActOnFinishInspectStmt(SourceLocation InspectLoc, Stmt *Inspect,
                                     Stmt *Body);
   StmtResult ActOnWhileStmt(SourceLocation WhileLoc, ConditionResult Cond,

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -6043,12 +6043,13 @@ ExpectedStmt ASTNodeImporter::VisitInspectStmt(InspectStmt *S) {
   auto ToCond = importChecked(Err, S->getCond());
   auto ToInspectLoc = importChecked(Err, S->getInspectLoc());
   auto ToIsConstexpr = S->isConstexpr();
+  auto ToType = S->getTrailingReturnType();
   if (Err)
     return std::move(Err);
 
   auto *ToStmt =
       InspectStmt::Create(Importer.getToContext(), ToInit, ToConditionVariable,
-                          ToCond, ToIsConstexpr);
+                          ToCond, ToIsConstexpr, ToType);
   ToStmt->setInspectLoc(ToInspectLoc);
 
   // Now we have to re-chain the patterns.

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -127,9 +127,9 @@ CoroutineBodyStmt::CoroutineBodyStmt(CoroutineBodyStmt::CtorArgs const &Args)
 }
 
 InspectStmt::InspectStmt(const ASTContext &Ctx, Stmt *Init, VarDecl *Var,
-                         Expr *Cond, bool IsConstexpr)
+                         Expr *Cond, bool IsConstexpr, TypeResult ReturnType)
     : Stmt(InspectStmtClass), FirstPattern(nullptr),
-      ConstexprInspect(IsConstexpr) {
+      ConstexprInspect(IsConstexpr), TrailingReturnType(ReturnType) {
 
   bool HasInit = Init != nullptr;
   bool HasVar = Var != nullptr;
@@ -155,10 +155,11 @@ InspectStmt::InspectStmt(EmptyShell Empty, bool HasInit, bool HasVar)
 }
 
 InspectStmt *InspectStmt::Create(const ASTContext &Ctx, Stmt *Init,
-                                 VarDecl *Var, Expr *Cond, bool IsConstexpr) {
+                                 VarDecl *Var, Expr *Cond, bool IsConstexpr,
+                                 TypeResult ReturnType) {
   void *Mem = Ctx.Allocate(totalSizeToAlloc<Stmt *>(NumMandatoryStmtPtr),
                            alignof(InspectStmt));
-  return new (Mem) InspectStmt(Ctx, Init, Var, Cond, IsConstexpr);
+  return new (Mem) InspectStmt(Ctx, Init, Var, Cond, IsConstexpr, ReturnType);
 }
 
 InspectStmt *InspectStmt::CreateEmpty(const ASTContext &Ctx, bool HasInit,

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -1836,8 +1836,16 @@ StmtResult Parser::ParseInspectStatement(ParsedAttributesWithRange &attrs,
                                 Sema::ConditionKind::Inspect))
     return StmtError();
 
-  StmtResult Inspect = Actions.ActOnStartOfInspectStmt(InspectLoc, Init.get(),
-                                                       Cond, IsConstexpr);
+  // Parse trailing-return-type[opt].
+  TypeResult TrailingReturnType;
+  if (Tok.is(tok::arrow)) {
+    SourceRange Range;
+    TrailingReturnType =
+        ParseTrailingReturnType(Range, /*MayBeFollowedByDirectInit*/ false);
+  }
+
+  StmtResult Inspect = Actions.ActOnStartOfInspectStmt(
+      InspectLoc, Init.get(), Cond, IsConstexpr, TrailingReturnType);
   if (Inspect.isInvalid()) {
     // Skip the inspect body.
     if (Tok.is(tok::l_brace)) {

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -849,14 +849,15 @@ StmtResult Sema::ActOnStartOfSwitchStmt(SourceLocation SwitchLoc,
 
 StmtResult Sema::ActOnStartOfInspectStmt(SourceLocation InspectLoc,
                                          Stmt *InitStmt, ConditionResult Cond,
-                                         bool IsConstexpr) {
+                                         bool IsConstexpr,
+                                         TypeResult TrailingReturnType) {
   Expr *CondExpr = Cond.get().second;
   assert((Cond.isInvalid() || CondExpr) && "inspect with no condition");
 
   setFunctionHasBranchIntoScope();
 
   auto *IS = InspectStmt::Create(Context, InitStmt, Cond.get().first, CondExpr,
-                                 IsConstexpr);
+                                 IsConstexpr, TrailingReturnType);
   getCurFunction()->InspectStack.push_back(
       FunctionScopeInfo::InspectInfo(IS, false));
   return IS;

--- a/clang/test/Parser/cxx-inspect.cpp
+++ b/clang/test/Parser/cxx-inspect.cpp
@@ -17,3 +17,25 @@ void BasicWorkingInspects() {
 
   inspect constexpr(42) {}
 }
+
+void trailingReturnTypes() {
+  inspect(42) -> int {
+    __:;
+  }
+
+  inspect(42) -> decltype(1) {
+    __:;
+  }
+
+  inspect(42) -> void {
+    __:;
+  }
+
+  inspect(42) -> { // expected-error {{expected a type}}
+    __:;
+  }
+
+  inspect(42) -> foo { // expected-error {{unknown type name 'foo'}}
+    __:;
+  }
+}


### PR DESCRIPTION
- Had to rename a local type in ExprConstant.cpp due to collision
- Added some testing to demonstrate parsing