### PR TITLE
Parse the inspect expression body with ParseCompoundStatementBody

### DIFF
--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -3990,7 +3990,7 @@ ExprResult Parser::ParseInspectExpr() {
   //
   // inspect (...) { ... }
   //               ^
-  StmtResult Body(ParseStatement());
+  StmtResult Body(ParseCompoundStatementBody(/*bool isStmtExpr*/true));
 
   // Pop the scopes.
   InnerScope.Exit();

--- a/clang/test/Parser/cxx-inspect.cpp
+++ b/clang/test/Parser/cxx-inspect.cpp
@@ -3,13 +3,19 @@
 void noParen() {
   inspect 42 { // expected-error {{expected '(' after 'inspect'}}
     __ => {};
-  }
+  };
 }
 
 void noParenConstExpr() {
   inspect constexpr 42 { // expected-error {{expected '(' after 'constexpr'}}
     __ => {};
-  }
+  };
+}
+
+void noSemiColon() {
+  inspect(42) {
+    __ => {};
+  } // expected-error {{expected ';' after expression}}
 }
 
 void trailingReturnTypes() {


### PR DESCRIPTION
- Similar to how lambda expressions are parsed
- Existing tests still pass
- Able to add new passing test diagnosing missing semicolon