### PR TITLE
Implement manual exclusion of patterns from type deduction (parsing and sema only)

### DIFF
--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -992,6 +992,11 @@ protected:
     /// patterns)
     unsigned HasCase : 1;
 
+    /// Used by PatternStmt to discover whether a
+    /// pattern statement contributes to return type deduction
+    /// for the overall inspect expression
+    unsigned PatternStmtExcludedFromTypeDeduction : 1;
+
     /// The location of the '__' wildcard, identifier or
     /// constant expression.
     SourceLocation PatternLoc;
@@ -3641,14 +3646,19 @@ protected:
   /// The location of the ":".
   SourceLocation ColonLoc;
 
+  /// The location of the "!" (type deduction exclusion marker) if present
+  SourceLocation ExclaimLoc;
+
   /// A pointer to the following PatternStmt class in the same
   /// inspect statement.
   PatternStmt *NextPattern = nullptr;
 
-  PatternStmt(StmtClass SC, SourceLocation KWLoc, SourceLocation ColonLoc)
+  PatternStmt(StmtClass SC, SourceLocation KWLoc, SourceLocation ColonLoc,
+              SourceLocation ExclaimLoc)
       : Stmt(SC), ColonLoc(ColonLoc) {
     setPatternLoc(KWLoc);
     setHasCase(false);
+    setExclaimLoc(ExclaimLoc);
   }
 
   PatternStmt(StmtClass SC, EmptyShell) : Stmt(SC) {}
@@ -3678,6 +3688,15 @@ public:
 
   inline void setHasCase(bool HasCase) { InspectPatternBits.HasCase = HasCase; }
   inline bool hasCase() const { return InspectPatternBits.HasCase; }
+
+  SourceLocation getExclaimLoc() const { return ExclaimLoc; }
+  void setExclaimLoc(SourceLocation L) {
+    ExclaimLoc = L;
+    InspectPatternBits.PatternStmtExcludedFromTypeDeduction = L.isValid();
+  }
+  inline bool excludedFromTypeDeduction() const {
+    return InspectPatternBits.PatternStmtExcludedFromTypeDeduction;
+  }
 
   SourceLocation getBeginLoc() const { return getPatternLoc(); }
   inline SourceLocation getEndLoc() const LLVM_READONLY;
@@ -3714,8 +3733,9 @@ class WildcardPatternStmt final
 
 public:
   WildcardPatternStmt(SourceLocation PatternLoc, SourceLocation ColonLoc,
-                      Stmt *SubStmt, Expr *Guard)
-      : PatternStmt(WildcardPatternStmtClass, PatternLoc, ColonLoc) {
+                      Stmt *SubStmt, Expr *Guard, SourceLocation ExclaimLoc)
+      : PatternStmt(WildcardPatternStmtClass, PatternLoc, ColonLoc,
+                    ExclaimLoc) {
     setSubStmt(SubStmt);
     if (Guard) {
       InspectPatternBits.PatternStmtHasPatternGuard = true;
@@ -3733,7 +3753,8 @@ public:
   static WildcardPatternStmt *Create(const ASTContext &Ctx,
                                      SourceLocation PatternLoc,
                                      SourceLocation ColonLoc,
-                                     Expr *patternGuard);
+                                     Expr *patternGuard,
+                                     SourceLocation ExclaimLoc);
 
   /// Build an empty wildcard pattern statement.
   static WildcardPatternStmt *CreateEmpty(const ASTContext &Ctx,
@@ -3833,8 +3854,10 @@ class IdentifierPatternStmt final
 
 public:
   IdentifierPatternStmt(SourceLocation PatternLoc, SourceLocation ColonLoc,
-                        Stmt *VD, Stmt *SubStmt, Expr *Guard)
-      : PatternStmt(IdentifierPatternStmtClass, PatternLoc, ColonLoc) {
+                        Stmt *VD, Stmt *SubStmt, Expr *Guard,
+                        SourceLocation ExclaimLoc)
+      : PatternStmt(IdentifierPatternStmtClass, PatternLoc, ColonLoc,
+                    ExclaimLoc) {
     setSubStmt(SubStmt);
     setVar(VD);
 
@@ -3854,7 +3877,8 @@ public:
   static IdentifierPatternStmt *Create(const ASTContext &Ctx,
                                        SourceLocation PatternLoc,
                                        SourceLocation ColonLoc,
-                                       Expr *patternGuard);
+                                       Expr *patternGuard,
+                                       SourceLocation ExclaimLoc);
 
   /// Build an empty identifier pattern statement.
   static IdentifierPatternStmt *CreateEmpty(const ASTContext &Ctx,
@@ -3963,8 +3987,10 @@ class ExpressionPatternStmt final
 
 public:
   ExpressionPatternStmt(SourceLocation PatternLoc, SourceLocation ColonLoc,
-                        Stmt *MatchCond, Stmt *SubStmt, Expr *Guard)
-      : PatternStmt(ExpressionPatternStmtClass, PatternLoc, ColonLoc) {
+                        Stmt *MatchCond, Stmt *SubStmt, Expr *Guard,
+                        SourceLocation ExclaimLoc)
+      : PatternStmt(ExpressionPatternStmtClass, PatternLoc, ColonLoc,
+                    ExclaimLoc) {
     setSubStmt(SubStmt);
     setMatchCond(MatchCond);
 
@@ -3984,7 +4010,8 @@ public:
   static ExpressionPatternStmt *Create(const ASTContext &Ctx,
                                        SourceLocation PatternLoc,
                                        SourceLocation ColonLoc,
-                                       Expr *patternGuard);
+                                       Expr *patternGuard,
+                                       SourceLocation ExclaimLoc);
 
   /// Build an empty expression pattern statement.
   static ExpressionPatternStmt *CreateEmpty(const ASTContext &Ctx,

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7361,6 +7361,9 @@ def err_typecheck_pattern_type_incompatible : Error<
   "resulting expression type must match trailing result type}0,1}2"
   >;
 
+def err_typecheck_no_valid_return_type : Error<
+  "no valid type can be deduced for inspect expression">;
+
 def note_incomplete_class_and_qualified_id : Note<
   "conformance of forward class %0 to protocol %1 can not be confirmed">;
 def warn_incompatible_qualified_id : Warning<

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -4202,15 +4202,16 @@ public:
   StmtResult ActOnWildcardPattern(SourceLocation WildcardLoc,
                                   SourceLocation ColonLoc, Stmt *SubStmt,
                                   Expr *PatternGuard,
-                                  SourceLocation ExclaimLoc);
+                                  bool ExcludedFromTypeDeduction);
   StmtResult ActOnIdentifierPattern(SourceLocation IdentifierLoc,
                                     SourceLocation ColonLoc, IdentifierInfo *II,
                                     Stmt *SubStmt, Expr *PatternGuard,
-                                    SourceLocation ExclaimLoc);
+                                    bool ExcludedFromTypeDeduction);
   StmtResult ActOnExpressionPattern(SourceLocation CstExprLoc,
                                     SourceLocation ColonLoc, Expr *CstExpr,
                                     Stmt *SubStmt, Expr *PatternGuard,
-                                    bool HasCase, SourceLocation ExclaimLoc);
+                                    bool HasCase,
+                                    bool ExcludedFromTypeDeduction);
   ExprResult CheckPatternConstantExpr(Expr *MatchExpr,
                                       SourceLocation MatchExprLoc);
   class ConditionResult;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -4201,14 +4201,16 @@ public:
   // pattern matching patterns
   StmtResult ActOnWildcardPattern(SourceLocation WildcardLoc,
                                   SourceLocation ColonLoc, Stmt *SubStmt,
-                                  Expr *PatternGuard);
+                                  Expr *PatternGuard,
+                                  SourceLocation ExclaimLoc);
   StmtResult ActOnIdentifierPattern(SourceLocation IdentifierLoc,
                                     SourceLocation ColonLoc, IdentifierInfo *II,
-                                    Stmt *SubStmt, Expr *PatternGuard);
+                                    Stmt *SubStmt, Expr *PatternGuard,
+                                    SourceLocation ExclaimLoc);
   StmtResult ActOnExpressionPattern(SourceLocation CstExprLoc,
                                     SourceLocation ColonLoc, Expr *CstExpr,
                                     Stmt *SubStmt, Expr *PatternGuard,
-                                    bool HasCase);
+                                    bool HasCase, SourceLocation ExclaimLoc);
   ExprResult CheckPatternConstantExpr(Expr *MatchExpr,
                                       SourceLocation MatchExprLoc);
   class ConditionResult;

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -6075,11 +6075,13 @@ ExpectedStmt ASTNodeImporter::VisitWildcardPatternStmt(WildcardPatternStmt *S) {
   auto ToPatternLoc = importChecked(Err, S->getPatternLoc());
   auto ToColonLoc = importChecked(Err, S->getColonLoc());
   auto ToPatternGuard = importChecked(Err, S->getPatternGuard());
+  auto ToExclaimLoc = importChecked(Err, S->getExclaimLoc());
   if (Err)
     return std::move(Err);
 
-  auto *ToStmt = WildcardPatternStmt::Create(
-      Importer.getToContext(), ToPatternLoc, ToColonLoc, ToPatternGuard);
+  auto *ToStmt =
+      WildcardPatternStmt::Create(Importer.getToContext(), ToPatternLoc,
+                                  ToColonLoc, ToPatternGuard, ToExclaimLoc);
   ToStmt->setSubStmt(ToSubStmt);
 
   return ToStmt;
@@ -6093,11 +6095,13 @@ ASTNodeImporter::VisitIdentifierPatternStmt(IdentifierPatternStmt *S) {
   auto ToColonLoc = importChecked(Err, S->getColonLoc());
   auto ToVar = importChecked(Err, S->getVar());
   auto ToPatternGuard = importChecked(Err, S->getPatternGuard());
+  auto ToExclaimLoc = importChecked(Err, S->getExclaimLoc());
   if (Err)
     return std::move(Err);
 
-  auto *ToStmt = IdentifierPatternStmt::Create(
-      Importer.getToContext(), ToPatternLoc, ToColonLoc, ToPatternGuard);
+  auto *ToStmt =
+      IdentifierPatternStmt::Create(Importer.getToContext(), ToPatternLoc,
+                                    ToColonLoc, ToPatternGuard, ToExclaimLoc);
   ToStmt->setVar(ToVar);
   ToStmt->setSubStmt(ToSubStmt);
 
@@ -6112,11 +6116,13 @@ ASTNodeImporter::VisitExpressionPatternStmt(ExpressionPatternStmt *S) {
   auto ToColonLoc = importChecked(Err, S->getColonLoc());
   auto ToCond = importChecked(Err, S->getMatchCond());
   auto ToPatternGuard = importChecked(Err, S->getPatternGuard());
+  auto ToExclaimLoc = importChecked(Err, S->getExclaimLoc());
   if (Err)
     return std::move(Err);
 
-  auto *ToStmt = ExpressionPatternStmt::Create(
-      Importer.getToContext(), ToPatternLoc, ToColonLoc, ToPatternGuard);
+  auto *ToStmt =
+      ExpressionPatternStmt::Create(Importer.getToContext(), ToPatternLoc,
+                                    ToColonLoc, ToPatternGuard, ToExclaimLoc);
   ToStmt->setMatchCond(ToCond);
   ToStmt->setSubStmt(ToSubStmt);
 

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -6075,13 +6075,13 @@ ExpectedStmt ASTNodeImporter::VisitWildcardPatternStmt(WildcardPatternStmt *S) {
   auto ToPatternLoc = importChecked(Err, S->getPatternLoc());
   auto ToColonLoc = importChecked(Err, S->getColonLoc());
   auto ToPatternGuard = importChecked(Err, S->getPatternGuard());
-  auto ToExclaimLoc = importChecked(Err, S->getExclaimLoc());
+  auto ExcludedFromTypeDeduction = S->excludedFromTypeDeduction();
   if (Err)
     return std::move(Err);
 
-  auto *ToStmt =
-      WildcardPatternStmt::Create(Importer.getToContext(), ToPatternLoc,
-                                  ToColonLoc, ToPatternGuard, ToExclaimLoc);
+  auto *ToStmt = WildcardPatternStmt::Create(
+      Importer.getToContext(), ToPatternLoc, ToColonLoc, ToPatternGuard,
+      ExcludedFromTypeDeduction);
   ToStmt->setSubStmt(ToSubStmt);
 
   return ToStmt;
@@ -6095,13 +6095,13 @@ ASTNodeImporter::VisitIdentifierPatternStmt(IdentifierPatternStmt *S) {
   auto ToColonLoc = importChecked(Err, S->getColonLoc());
   auto ToVar = importChecked(Err, S->getVar());
   auto ToPatternGuard = importChecked(Err, S->getPatternGuard());
-  auto ToExclaimLoc = importChecked(Err, S->getExclaimLoc());
+  auto ExcludedFromTypeDeduction = S->excludedFromTypeDeduction();
   if (Err)
     return std::move(Err);
 
-  auto *ToStmt =
-      IdentifierPatternStmt::Create(Importer.getToContext(), ToPatternLoc,
-                                    ToColonLoc, ToPatternGuard, ToExclaimLoc);
+  auto *ToStmt = IdentifierPatternStmt::Create(
+      Importer.getToContext(), ToPatternLoc, ToColonLoc, ToPatternGuard,
+      ExcludedFromTypeDeduction);
   ToStmt->setVar(ToVar);
   ToStmt->setSubStmt(ToSubStmt);
 
@@ -6116,13 +6116,13 @@ ASTNodeImporter::VisitExpressionPatternStmt(ExpressionPatternStmt *S) {
   auto ToColonLoc = importChecked(Err, S->getColonLoc());
   auto ToCond = importChecked(Err, S->getMatchCond());
   auto ToPatternGuard = importChecked(Err, S->getPatternGuard());
-  auto ToExclaimLoc = importChecked(Err, S->getExclaimLoc());
+  auto ExcludedFromTypeDeduction = S->excludedFromTypeDeduction();
   if (Err)
     return std::move(Err);
 
-  auto *ToStmt =
-      ExpressionPatternStmt::Create(Importer.getToContext(), ToPatternLoc,
-                                    ToColonLoc, ToPatternGuard, ToExclaimLoc);
+  auto *ToStmt = ExpressionPatternStmt::Create(
+      Importer.getToContext(), ToPatternLoc, ToColonLoc, ToPatternGuard,
+      ExcludedFromTypeDeduction);
   ToStmt->setMatchCond(ToCond);
   ToStmt->setSubStmt(ToSubStmt);
 

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -126,18 +126,17 @@ CoroutineBodyStmt::CoroutineBodyStmt(CoroutineBodyStmt::CtorArgs const &Args)
             const_cast<Stmt **>(getParamMoves().data()));
 }
 
-WildcardPatternStmt *WildcardPatternStmt::Create(const ASTContext &Ctx,
-                                                 SourceLocation WildcardLoc,
-                                                 SourceLocation ColonLoc,
-                                                 Expr *PatternGuard,
-                                                 SourceLocation ExclaimLoc) {
+WildcardPatternStmt *
+WildcardPatternStmt::Create(const ASTContext &Ctx, SourceLocation WildcardLoc,
+                            SourceLocation ColonLoc, Expr *PatternGuard,
+                            bool ExcludedFromTypeDeduction) {
   bool HasPatternGuard = PatternGuard != nullptr;
 
   void *Mem = Ctx.Allocate(
       totalSizeToAlloc<Stmt *>(NumMandatoryStmtPtr + HasPatternGuard),
       alignof(WildcardPatternStmt));
   return new (Mem) WildcardPatternStmt(WildcardLoc, ColonLoc, nullptr,
-                                       PatternGuard, ExclaimLoc);
+                                       PatternGuard, ExcludedFromTypeDeduction);
 }
 
 WildcardPatternStmt *WildcardPatternStmt::CreateEmpty(const ASTContext &Ctx,
@@ -151,14 +150,15 @@ WildcardPatternStmt *WildcardPatternStmt::CreateEmpty(const ASTContext &Ctx,
 IdentifierPatternStmt *
 IdentifierPatternStmt::Create(const ASTContext &Ctx, SourceLocation CaseLoc,
                               SourceLocation ColonLoc, Expr *PatternGuard,
-                              SourceLocation ExclaimLoc) {
+                              bool ExcludedFromTypeDeduction) {
   bool HasPatternGuard = PatternGuard != nullptr;
 
   void *Mem = Ctx.Allocate(
       totalSizeToAlloc<Stmt *>(NumMandatoryStmtPtr + HasPatternGuard),
       alignof(IdentifierPatternStmt));
-  return new (Mem) IdentifierPatternStmt(CaseLoc, ColonLoc, nullptr, nullptr,
-                                         PatternGuard, ExclaimLoc);
+  return new (Mem)
+      IdentifierPatternStmt(CaseLoc, ColonLoc, nullptr, nullptr, PatternGuard,
+                            ExcludedFromTypeDeduction);
 }
 
 IdentifierPatternStmt *
@@ -173,14 +173,15 @@ IdentifierPatternStmt::CreateEmpty(const ASTContext &Ctx,
 ExpressionPatternStmt *
 ExpressionPatternStmt::Create(const ASTContext &Ctx, SourceLocation CaseLoc,
                               SourceLocation ColonLoc, Expr *PatternGuard,
-                              SourceLocation ExclaimLoc) {
+                              bool ExcludedFromTypeDeduction) {
   bool HasPatternGuard = PatternGuard != nullptr;
 
   void *Mem = Ctx.Allocate(
       totalSizeToAlloc<Stmt *>(NumMandatoryStmtPtr + HasPatternGuard),
       alignof(IdentifierPatternStmt));
-  return new (Mem) ExpressionPatternStmt(CaseLoc, ColonLoc, nullptr, nullptr,
-                                         PatternGuard, ExclaimLoc);
+  return new (Mem)
+      ExpressionPatternStmt(CaseLoc, ColonLoc, nullptr, nullptr, PatternGuard,
+                            ExcludedFromTypeDeduction);
 }
 
 ExpressionPatternStmt *

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -129,14 +129,15 @@ CoroutineBodyStmt::CoroutineBodyStmt(CoroutineBodyStmt::CtorArgs const &Args)
 WildcardPatternStmt *WildcardPatternStmt::Create(const ASTContext &Ctx,
                                                  SourceLocation WildcardLoc,
                                                  SourceLocation ColonLoc,
-                                                 Expr *PatternGuard) {
+                                                 Expr *PatternGuard,
+                                                 SourceLocation ExclaimLoc) {
   bool HasPatternGuard = PatternGuard != nullptr;
 
   void *Mem = Ctx.Allocate(
       totalSizeToAlloc<Stmt *>(NumMandatoryStmtPtr + HasPatternGuard),
       alignof(WildcardPatternStmt));
-  return new (Mem)
-      WildcardPatternStmt(WildcardLoc, ColonLoc, nullptr, PatternGuard);
+  return new (Mem) WildcardPatternStmt(WildcardLoc, ColonLoc, nullptr,
+                                       PatternGuard, ExclaimLoc);
 }
 
 WildcardPatternStmt *WildcardPatternStmt::CreateEmpty(const ASTContext &Ctx,
@@ -147,17 +148,17 @@ WildcardPatternStmt *WildcardPatternStmt::CreateEmpty(const ASTContext &Ctx,
   return new (Mem) WildcardPatternStmt(EmptyShell(), HasPatternGuard);
 }
 
-IdentifierPatternStmt *IdentifierPatternStmt::Create(const ASTContext &Ctx,
-                                                     SourceLocation CaseLoc,
-                                                     SourceLocation ColonLoc,
-                                                     Expr *PatternGuard) {
+IdentifierPatternStmt *
+IdentifierPatternStmt::Create(const ASTContext &Ctx, SourceLocation CaseLoc,
+                              SourceLocation ColonLoc, Expr *PatternGuard,
+                              SourceLocation ExclaimLoc) {
   bool HasPatternGuard = PatternGuard != nullptr;
 
   void *Mem = Ctx.Allocate(
       totalSizeToAlloc<Stmt *>(NumMandatoryStmtPtr + HasPatternGuard),
       alignof(IdentifierPatternStmt));
-  return new (Mem)
-      IdentifierPatternStmt(CaseLoc, ColonLoc, nullptr, nullptr, PatternGuard);
+  return new (Mem) IdentifierPatternStmt(CaseLoc, ColonLoc, nullptr, nullptr,
+                                         PatternGuard, ExclaimLoc);
 }
 
 IdentifierPatternStmt *
@@ -169,17 +170,17 @@ IdentifierPatternStmt::CreateEmpty(const ASTContext &Ctx,
   return new (Mem) IdentifierPatternStmt(EmptyShell(), HasPatternGuard);
 }
 
-ExpressionPatternStmt *ExpressionPatternStmt::Create(const ASTContext &Ctx,
-                                                     SourceLocation CaseLoc,
-                                                     SourceLocation ColonLoc,
-                                                     Expr *PatternGuard) {
+ExpressionPatternStmt *
+ExpressionPatternStmt::Create(const ASTContext &Ctx, SourceLocation CaseLoc,
+                              SourceLocation ColonLoc, Expr *PatternGuard,
+                              SourceLocation ExclaimLoc) {
   bool HasPatternGuard = PatternGuard != nullptr;
 
   void *Mem = Ctx.Allocate(
       totalSizeToAlloc<Stmt *>(NumMandatoryStmtPtr + HasPatternGuard),
       alignof(IdentifierPatternStmt));
-  return new (Mem)
-      ExpressionPatternStmt(CaseLoc, ColonLoc, nullptr, nullptr, PatternGuard);
+  return new (Mem) ExpressionPatternStmt(CaseLoc, ColonLoc, nullptr, nullptr,
+                                         PatternGuard, ExclaimLoc);
 }
 
 ExpressionPatternStmt *

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -755,7 +755,20 @@ StmtResult Parser::ParseWildcardPattern(ParsedStmtContext StmtCtx) {
     SkipUntil(tok::semi);
     return StmtError();
   }
-  SourceLocation ColonLoc = ConsumeToken();
+  SourceLocation ArrowLoc = ConsumeToken();
+
+  // Parse whether this pattern contributes to
+  // return type deduction
+  SourceLocation ExclaimLoc;
+  if (Tok.is(tok::exclaim)) {
+    ExclaimLoc = ConsumeToken();
+
+    if (!Tok.is(tok::l_brace)) {
+      Diag(Tok, diag::err_expected_lbrace_after) << "!";
+      SkipUntil(tok::semi);
+      return StmtError();
+    }
+  }
 
   // Parse the statement
   //
@@ -767,12 +780,12 @@ StmtResult Parser::ParseWildcardPattern(ParsedStmtContext StmtCtx) {
   // Broken substmt shouldn't prevent the identifier from being added to the
   // AST.
   if (SubStmt.isInvalid())
-    SubStmt = Actions.ActOnNullStmt(ColonLoc);
+    SubStmt = Actions.ActOnNullStmt(ArrowLoc);
 
   PatternScope.Exit();
 
-  return Actions.ActOnWildcardPattern(WildcardLoc, ColonLoc, SubStmt.get(),
-                                      Cond.get().second);
+  return Actions.ActOnWildcardPattern(WildcardLoc, ArrowLoc, SubStmt.get(),
+                                      Cond.get().second, ExclaimLoc);
 }
 
 /// ParseIdentifierPattern - We have an identifier that matches any value
@@ -811,10 +824,23 @@ StmtResult Parser::ParseIdentifierPattern(ParsedStmtContext StmtCtx) {
     if (Tok.is(tok::equal) && NextToken().is(tok::greater))
       ConsumeToken();
   }
-  SourceLocation ColonLoc = ConsumeToken();
+  SourceLocation ArrowLoc = ConsumeToken();
 
-  auto IPS = Actions.ActOnIdentifierPattern(IdentifierLoc, ColonLoc, II,
-                                            nullptr, Cond.get().second);
+  // Parse whether this pattern contributes to
+  // return type deduction
+  SourceLocation ExclaimLoc;
+  if (Tok.is(tok::exclaim)) {
+    ExclaimLoc = ConsumeToken();
+
+    if (!Tok.is(tok::l_brace)) {
+      Diag(Tok, diag::err_expected_lbrace_after) << "!";
+      SkipUntil(tok::semi);
+      return StmtError();
+    }
+  }
+
+  auto IPS = Actions.ActOnIdentifierPattern(
+      IdentifierLoc, ArrowLoc, II, nullptr, Cond.get().second, ExclaimLoc);
 
   // Parse the statement
   //
@@ -826,7 +852,7 @@ StmtResult Parser::ParseIdentifierPattern(ParsedStmtContext StmtCtx) {
   // Broken substmt shouldn't prevent the identifier from being added to the
   // AST.
   if (SubStmt.isInvalid())
-    SubStmt = Actions.ActOnNullStmt(ColonLoc);
+    SubStmt = Actions.ActOnNullStmt(ArrowLoc);
 
   IdentifierPatternStmt *IP = dyn_cast<IdentifierPatternStmt>(IPS.get());
   IP->setSubStmt(SubStmt.get());
@@ -883,7 +909,20 @@ StmtResult Parser::ParseExpressionPattern(ParsedStmtContext StmtCtx,
     if (Tok.is(tok::equal) && NextToken().is(tok::greater))
       ConsumeToken();
   }
-  SourceLocation ColonLoc = ConsumeToken();
+  SourceLocation ArrowLoc = ConsumeToken();
+
+  // Parse whether this pattern contributes to
+  // return type deduction
+  SourceLocation ExclaimLoc;
+  if (Tok.is(tok::exclaim)) {
+    ExclaimLoc = ConsumeToken();
+
+    if (!Tok.is(tok::l_brace)) {
+      Diag(Tok, diag::err_expected_lbrace_after) << "!";
+      SkipUntil(tok::semi);
+      return StmtError();
+    }
+  }
 
   // Parse the statement
   //
@@ -892,13 +931,13 @@ StmtResult Parser::ParseExpressionPattern(ParsedStmtContext StmtCtx,
   //                                             ^
   StmtResult SubStmt = ParseStatement(nullptr, StmtCtx);
   if (SubStmt.isInvalid())
-    SubStmt = Actions.ActOnNullStmt(ColonLoc);
+    SubStmt = Actions.ActOnNullStmt(ArrowLoc);
   if (Matcher.isInvalid())
     return StmtError();
 
   auto EPS =
-      Actions.ActOnExpressionPattern(MatcherLoc, ColonLoc, Matcher.get(),
-                                     SubStmt.get(), Cond.get().second, HasCase);
+      Actions.ActOnExpressionPattern(MatcherLoc, ArrowLoc, Matcher.get(),
+                                     SubStmt.get(), Cond.get().second, HasCase, ExclaimLoc);
 
   PatternScope.Exit();
   return EPS;

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -785,7 +785,7 @@ StmtResult Parser::ParseWildcardPattern(ParsedStmtContext StmtCtx) {
   PatternScope.Exit();
 
   return Actions.ActOnWildcardPattern(WildcardLoc, ArrowLoc, SubStmt.get(),
-                                      Cond.get().second, ExclaimLoc);
+                                      Cond.get().second, ExclaimLoc.isValid());
 }
 
 /// ParseIdentifierPattern - We have an identifier that matches any value
@@ -839,8 +839,9 @@ StmtResult Parser::ParseIdentifierPattern(ParsedStmtContext StmtCtx) {
     }
   }
 
-  auto IPS = Actions.ActOnIdentifierPattern(
-      IdentifierLoc, ArrowLoc, II, nullptr, Cond.get().second, ExclaimLoc);
+  auto IPS =
+      Actions.ActOnIdentifierPattern(IdentifierLoc, ArrowLoc, II, nullptr,
+                                     Cond.get().second, ExclaimLoc.isValid());
 
   // Parse the statement
   //
@@ -935,9 +936,9 @@ StmtResult Parser::ParseExpressionPattern(ParsedStmtContext StmtCtx,
   if (Matcher.isInvalid())
     return StmtError();
 
-  auto EPS =
-      Actions.ActOnExpressionPattern(MatcherLoc, ArrowLoc, Matcher.get(),
-                                     SubStmt.get(), Cond.get().second, HasCase, ExclaimLoc);
+  auto EPS = Actions.ActOnExpressionPattern(MatcherLoc, ArrowLoc, Matcher.get(),
+                                            SubStmt.get(), Cond.get().second,
+                                            HasCase, ExclaimLoc.isValid());
 
   PatternScope.Exit();
   return EPS;

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -8769,13 +8769,22 @@ ExprResult Sema::ActOnFinishInspectExpr(SourceLocation InspectLoc,
     return QualType();
   };
 
-  // Inspect must have at least one pattern
   if (!P)
     return ExprError();
 
-  QualType ResTy =
-      (IE->hasExplicitResultType() ? IE->getType() : getPatternExprType(P))
-          .getUnqualifiedType();
+  // See if we can deduce a type for the inspect expression
+  // at this point, using either the explicit return type or the
+  // deduced return type of the first pattern.
+  // If there is no explicit type deduction and the first pattern
+  // is manually excluded from type deduction, we will have to
+  // start deducing the type from the first pattern that is not
+  // excluded from type deduction.
+  Optional<QualType> ResTy;
+  if (IE->hasExplicitResultType()) {
+    ResTy = IE->getType();
+  } else if (!P->excludedFromTypeDeduction()) {
+    ResTy = getPatternExprType(P).getUnqualifiedType();
+  }
 
   // Check all patterns return the same type by comparing to either
   // the trailing result type or resulting type found in first pattern's
@@ -8784,17 +8793,41 @@ ExprResult Sema::ActOnFinishInspectExpr(SourceLocation InspectLoc,
     // FIXME: Should we be looking into the unqualified type here?
     QualType PatternResTy = getPatternExprType(P).getUnqualifiedType();
 
-    if (Context.getCanonicalType(ResTy) ==
-        Context.getCanonicalType(PatternResTy))
+    // several reasons we may consider this pattern "good" from
+    // a type deduction point of view:
+
+    // 1: This pattern matches the current candidate type
+    if (ResTy) {
+      if (Context.getCanonicalType(*ResTy) ==
+          Context.getCanonicalType(PatternResTy))
+        continue;
+    }
+
+    // 2: There is no current candidate return type and this
+    // pattern is providing that type.
+    if (!ResTy && !P->excludedFromTypeDeduction()) {
+      ResTy = getPatternExprType(P).getUnqualifiedType();
+      continue;
+    }
+
+    // 3: This pattern is excluded from type deduction
+    if (P->excludedFromTypeDeduction())
       continue;
 
     Diag(P->getSubStmt()->getBeginLoc(),
          diag::err_typecheck_pattern_type_incompatible)
-        << PatternResTy << ResTy << IE->hasExplicitResultType();
+        << PatternResTy << *ResTy << IE->hasExplicitResultType();
   }
 
-  if (!IE->hasExplicitResultType())
-    IE->setType(ResTy);
+  // We should know a return type for the inspect expression
+  // by this time. We should provide a diag if this is not the case.
+  if (!IE->hasExplicitResultType()) {
+    if (ResTy) {
+      IE->setType(*ResTy);
+    } else {
+      return ExprError();
+    }
+  }
 
   // TODO: exaustiviness checking...
   return IE;

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -8803,12 +8803,12 @@ ExprResult Sema::ActOnFinishInspectExpr(SourceLocation InspectLoc,
       // FIXME: Should we be looking into the unqualified type here?
       ResTy = PatternResTy.getUnqualifiedType();
       continue;
-    } else {
-      // This pattern matches the current candidate type
-      if (Context.getCanonicalType(ResTy) ==
-          Context.getCanonicalType(PatternResTy))
-        continue;
     }
+
+    // This pattern matches the current candidate type
+    if (Context.getCanonicalType(ResTy) ==
+        Context.getCanonicalType(PatternResTy))
+      continue;
 
     Diag(P->getSubStmt()->getBeginLoc(),
          diag::err_typecheck_pattern_type_incompatible)
@@ -8817,14 +8817,12 @@ ExprResult Sema::ActOnFinishInspectExpr(SourceLocation InspectLoc,
 
   // We should know a return type for the inspect expression
   // by this time. We should provide a diag if this is not the case.
-  if (!IE->hasExplicitResultType()) {
-    if (!ResTy.isNull()) {
-      IE->setType(ResTy);
-    } else {
-      Diag(IE->getBeginLoc(), diag::err_typecheck_no_valid_return_type);
-      return ExprError();
-    }
+  if (!IE->hasExplicitResultType() && ResTy.isNull()) {
+    Diag(IE->getBeginLoc(), diag::err_typecheck_no_valid_return_type);
+    return ExprError();
   }
+
+  IE->setType(ResTy);
 
   // TODO: exaustiveness checking...
   return IE;

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -8757,6 +8757,8 @@ ExprResult Sema::ActOnFinishInspectExpr(SourceLocation InspectLoc,
     // happen when (1) empty pattern body or (2) error recovery when expression
     // type does not match the trailing result type. In all cases treat as
     // the expression has void type.
+    if (PS->excludedFromTypeDeduction())
+      return QualType();
     if (isa<CompoundStmt>(PS->getSubStmt()) || isa<NullStmt>(P->getSubStmt()))
       return Context.VoidTy;
     if (auto *S = dyn_cast<WildcardPatternStmt>(PS))
@@ -8779,56 +8781,51 @@ ExprResult Sema::ActOnFinishInspectExpr(SourceLocation InspectLoc,
   // is manually excluded from type deduction, we will have to
   // start deducing the type from the first pattern that is not
   // excluded from type deduction.
-  Optional<QualType> ResTy;
-  if (IE->hasExplicitResultType()) {
-    ResTy = IE->getType();
-  } else if (!P->excludedFromTypeDeduction()) {
-    ResTy = getPatternExprType(P).getUnqualifiedType();
-  }
+  QualType ResTy =
+      IE->hasExplicitResultType() ? IE->getType() : getPatternExprType(P);
+  if (!ResTy.isNull())
+    ResTy = ResTy.getUnqualifiedType();
 
   // Check all patterns return the same type by comparing to either
   // the trailing result type or resulting type found in first pattern's
   // expression.
   for (; P != nullptr; P = P->getNextPattern()) {
-    // FIXME: Should we be looking into the unqualified type here?
-    QualType PatternResTy = getPatternExprType(P).getUnqualifiedType();
+    QualType PatternResTy = getPatternExprType(P);
 
-    // several reasons we may consider this pattern "good" from
-    // a type deduction point of view:
+    // can't proceed meaningfully if the pattern doesn't play
+    // into type deduction
+    if (PatternResTy.isNull())
+      continue;
 
-    // 1: This pattern matches the current candidate type
-    if (ResTy) {
-      if (Context.getCanonicalType(*ResTy) ==
+    if (ResTy.isNull()) {
+      // There is no current candidate return type and this
+      // pattern is providing that type.
+      // FIXME: Should we be looking into the unqualified type here?
+      ResTy = PatternResTy.getUnqualifiedType();
+      continue;
+    } else {
+      // This pattern matches the current candidate type
+      if (Context.getCanonicalType(ResTy) ==
           Context.getCanonicalType(PatternResTy))
         continue;
     }
 
-    // 2: There is no current candidate return type and this
-    // pattern is providing that type.
-    if (!ResTy && !P->excludedFromTypeDeduction()) {
-      ResTy = getPatternExprType(P).getUnqualifiedType();
-      continue;
-    }
-
-    // 3: This pattern is excluded from type deduction
-    if (P->excludedFromTypeDeduction())
-      continue;
-
     Diag(P->getSubStmt()->getBeginLoc(),
          diag::err_typecheck_pattern_type_incompatible)
-        << PatternResTy << *ResTy << IE->hasExplicitResultType();
+        << PatternResTy << ResTy << IE->hasExplicitResultType();
   }
 
   // We should know a return type for the inspect expression
   // by this time. We should provide a diag if this is not the case.
   if (!IE->hasExplicitResultType()) {
-    if (ResTy) {
-      IE->setType(*ResTy);
+    if (!ResTy.isNull()) {
+      IE->setType(ResTy);
     } else {
+      Diag(IE->getBeginLoc(), diag::err_typecheck_no_valid_return_type);
       return ExprError();
     }
   }
 
-  // TODO: exaustiviness checking...
+  // TODO: exaustiveness checking...
   return IE;
 }

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -516,13 +516,14 @@ Sema::ActOnDefaultStmt(SourceLocation DefaultLoc, SourceLocation ColonLoc,
 
 StmtResult Sema::ActOnWildcardPattern(SourceLocation WildcardLoc,
                                       SourceLocation ColonLoc, Stmt *SubStmt,
-                                      Expr *PatternGuard) {
+                                      Expr *PatternGuard,
+                                      SourceLocation ExclaimLoc) {
 
   if (getCurFunction()->InspectStack.empty())
     return StmtError();
 
-  auto *WPS =
-      WildcardPatternStmt::Create(Context, WildcardLoc, ColonLoc, PatternGuard);
+  auto *WPS = WildcardPatternStmt::Create(Context, WildcardLoc, ColonLoc,
+                                          PatternGuard, ExclaimLoc);
   WPS->setSubStmt(SubStmt);
   getCurFunction()->InspectStack.back().getPointer()->addPattern(WPS);
   return WPS;
@@ -531,7 +532,8 @@ StmtResult Sema::ActOnWildcardPattern(SourceLocation WildcardLoc,
 StmtResult Sema::ActOnIdentifierPattern(SourceLocation IdentifierLoc,
                                         SourceLocation ColonLoc,
                                         IdentifierInfo *II, Stmt *SubStmt,
-                                        Expr *PatternGuard) {
+                                        Expr *PatternGuard,
+                                        SourceLocation ExclaimLoc) {
   if (getCurFunction()->InspectStack.empty())
     return StmtError();
   InspectExpr *Inspect = getCurFunction()->InspectStack.back().getPointer();
@@ -586,7 +588,7 @@ StmtResult Sema::ActOnIdentifierPattern(SourceLocation IdentifierLoc,
         ActOnDeclStmt(ConvertDeclToDeclGroup(NewVD), ColonLoc, ColonLoc);
 
   auto *IPS = IdentifierPatternStmt::Create(Context, IdentifierLoc, ColonLoc,
-                                            PatternGuard);
+                                            PatternGuard, ExclaimLoc);
   IPS->setVar(NewVDStmt.get());
   IPS->setSubStmt(SubStmt);
   Inspect->addPattern(IPS);
@@ -641,7 +643,7 @@ ExprResult Sema::CheckPatternConstantExpr(Expr *MatchExpr,
 StmtResult Sema::ActOnExpressionPattern(SourceLocation MatchExprLoc,
                                         SourceLocation ColonLoc,
                                         Expr *MatchExpr, Stmt *SubStmt,
-                                        Expr *PatternGuard, bool HasCase) {
+                                        Expr *PatternGuard, bool HasCase, SourceLocation ExclaimLoc) {
 
   if (getCurFunction()->InspectStack.empty() || !MatchExpr)
     return StmtError();
@@ -659,7 +661,7 @@ StmtResult Sema::ActOnExpressionPattern(SourceLocation MatchExprLoc,
                  Inspect->getCond(), ER.isInvalid() ? MatchExpr : ER.get());
 
   auto *EPS = ExpressionPatternStmt::Create(Context, MatchExprLoc, ColonLoc,
-                                            PatternGuard);
+                                            PatternGuard, ExclaimLoc);
   EPS->setMatchCond(MatchCond.get());
   EPS->setSubStmt(SubStmt);
   EPS->setHasCase(HasCase);

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -517,13 +517,13 @@ Sema::ActOnDefaultStmt(SourceLocation DefaultLoc, SourceLocation ColonLoc,
 StmtResult Sema::ActOnWildcardPattern(SourceLocation WildcardLoc,
                                       SourceLocation ColonLoc, Stmt *SubStmt,
                                       Expr *PatternGuard,
-                                      SourceLocation ExclaimLoc) {
+                                      bool ExcludedFromTypeDeduction) {
 
   if (getCurFunction()->InspectStack.empty())
     return StmtError();
 
-  auto *WPS = WildcardPatternStmt::Create(Context, WildcardLoc, ColonLoc,
-                                          PatternGuard, ExclaimLoc);
+  auto *WPS = WildcardPatternStmt::Create(
+      Context, WildcardLoc, ColonLoc, PatternGuard, ExcludedFromTypeDeduction);
   WPS->setSubStmt(SubStmt);
   getCurFunction()->InspectStack.back().getPointer()->addPattern(WPS);
   return WPS;
@@ -533,7 +533,7 @@ StmtResult Sema::ActOnIdentifierPattern(SourceLocation IdentifierLoc,
                                         SourceLocation ColonLoc,
                                         IdentifierInfo *II, Stmt *SubStmt,
                                         Expr *PatternGuard,
-                                        SourceLocation ExclaimLoc) {
+                                        bool ExcludedFromTypeDeduction) {
   if (getCurFunction()->InspectStack.empty())
     return StmtError();
   InspectExpr *Inspect = getCurFunction()->InspectStack.back().getPointer();
@@ -587,8 +587,9 @@ StmtResult Sema::ActOnIdentifierPattern(SourceLocation IdentifierLoc,
   auto NewVDStmt =
         ActOnDeclStmt(ConvertDeclToDeclGroup(NewVD), ColonLoc, ColonLoc);
 
-  auto *IPS = IdentifierPatternStmt::Create(Context, IdentifierLoc, ColonLoc,
-                                            PatternGuard, ExclaimLoc);
+  auto *IPS =
+      IdentifierPatternStmt::Create(Context, IdentifierLoc, ColonLoc,
+                                    PatternGuard, ExcludedFromTypeDeduction);
   IPS->setVar(NewVDStmt.get());
   IPS->setSubStmt(SubStmt);
   Inspect->addPattern(IPS);
@@ -643,7 +644,8 @@ ExprResult Sema::CheckPatternConstantExpr(Expr *MatchExpr,
 StmtResult Sema::ActOnExpressionPattern(SourceLocation MatchExprLoc,
                                         SourceLocation ColonLoc,
                                         Expr *MatchExpr, Stmt *SubStmt,
-                                        Expr *PatternGuard, bool HasCase, SourceLocation ExclaimLoc) {
+                                        Expr *PatternGuard, bool HasCase,
+                                        bool ExcludedFromTypeDeduction) {
 
   if (getCurFunction()->InspectStack.empty() || !MatchExpr)
     return StmtError();
@@ -660,8 +662,8 @@ StmtResult Sema::ActOnExpressionPattern(SourceLocation MatchExprLoc,
       ActOnBinOp(getCurScope(), MatchExprLoc, tok::TokenKind::equalequal,
                  Inspect->getCond(), ER.isInvalid() ? MatchExpr : ER.get());
 
-  auto *EPS = ExpressionPatternStmt::Create(Context, MatchExprLoc, ColonLoc,
-                                            PatternGuard, ExclaimLoc);
+  auto *EPS = ExpressionPatternStmt::Create(
+      Context, MatchExprLoc, ColonLoc, PatternGuard, ExcludedFromTypeDeduction);
   EPS->setMatchCond(MatchCond.get());
   EPS->setSubStmt(SubStmt);
   EPS->setHasCase(HasCase);

--- a/clang/test/Parser/cxx-inspect.cpp
+++ b/clang/test/Parser/cxx-inspect.cpp
@@ -51,6 +51,35 @@ void trailingReturnTypes() {
   };
 }
 
+void returnTypeDeduction() {
+  inspect(42) {
+    42 => 42;
+    43 => 43;
+    __ => !{}; // exclude last from type deduction
+  };
+
+  inspect(42) {
+    42 => 42;
+    __ => !{}; // exclude middle from type deduction
+    43 => 43;
+  };
+
+  inspect(42) {
+    __ => !{}; // exclude first from type deduction
+    42 => 42;
+    43 => 43;
+  };
+
+  inspect(42) {
+    __ => !{}; // exclude only pattern
+  };
+
+  inspect(42) {
+    42 => 42;
+    __ => !throw "whoops"; // expected-error {{expected '{' after '!'}}
+  };
+}
+
 // Identifier pattern parsing
 int id_pat0() {
   int x = 3;

--- a/clang/test/Parser/cxx-inspect.cpp
+++ b/clang/test/Parser/cxx-inspect.cpp
@@ -71,10 +71,6 @@ void returnTypeDeduction() {
   };
 
   inspect(42) {
-    __ => !{}; // exclude only pattern
-  };
-
-  inspect(42) {
     42 => 42;
     __ => !throw "whoops"; // expected-error {{expected '{' after '!'}}
   };

--- a/clang/test/SemaCXX/inspect.cpp
+++ b/clang/test/SemaCXX/inspect.cpp
@@ -9,6 +9,12 @@ void a() {
   };
 }
 
+void a2() {
+  inspect(42) { // expected-error {{no valid type can be deduced for inspect expression}}
+    __ => !{};
+  };
+}
+
 void b(int x) {
   inspect(x) -> void {
     __ => 3; // expected-error {{cannot initialize statement expression result of type 'void' with an rvalue of type 'int'}}

--- a/clang/test/SemaCXX/inspect.cpp
+++ b/clang/test/SemaCXX/inspect.cpp
@@ -42,6 +42,21 @@ void f(int x) {
   };
 }
 
+void baz() { }
+void f1(int x) {
+  inspect(x) -> int {
+    42 => 42;
+    __ => !{ baz(); }; // ok because not participating in type deduction
+  };
+}
+
+void f2(int x) {
+  inspect(x) -> int {
+    __ => !{ baz(); };  // ok because not participating in type deduction
+    42 => 42;
+  };
+}
+
 void g(int x) {
   inspect(x) -> void {
     1 => (void)3;


### PR DESCRIPTION
- '!' syntax to exclude individual patterns from type deduction
- Permitted for compound statements only, bare statements disallowed
- New test cases added for parsing and sema