### PR TITLE
[PatternMatching] Fix incorrect fallthrough from parsing '['

### DIFF
--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -1662,6 +1662,9 @@ ExprResult Parser::ParseCastExpression(CastParseKind ParseKind,
     cutOffParsing();
     return ExprError();
   }
+  case tok::kw_inspect: // C++2b Pattern Matching: inspect-statement
+    Res = ParseInspectExpr();
+    break;
   case tok::l_square:
     if (getLangOpts().CPlusPlus11) {
       if (getLangOpts().ObjC) {
@@ -1688,9 +1691,6 @@ ExprResult Parser::ParseCastExpression(CastParseKind ParseKind,
       break;
     }
     LLVM_FALLTHROUGH;
-  case tok::kw_inspect: // C++2b Pattern Matching: inspect-statement
-    Res = ParseInspectExpr();
-    break;
   default:
     NotCastExpr = true;
     return ExprError();

--- a/clang/unittests/ASTMatchers/ASTMatchersNodeTest.cpp
+++ b/clang/unittests/ASTMatchers/ASTMatchersNodeTest.cpp
@@ -1176,24 +1176,10 @@ TEST(SwitchCase, MatchesSwitch) {
 }
 
 TEST(PatternMatching, MatchesInspect) {
-  EXPECT_TRUE(matchesConditionally("void x() { inspect(42) { __:; } }", inspectExpr(), true, "-fpattern-matching"));
-  EXPECT_TRUE(matchesConditionally("void x() { inspect(42) { 42:; } }", inspectExpr(), true, "-fpattern-matching"));
-  EXPECT_TRUE(matchesConditionally("void x() { int y=0; inspect(42) { y:; } }", inspectExpr(), true, "-fpattern-matching"));
+  EXPECT_TRUE(matchesConditionally("void x() { inspect(42) { __ => {} }; }", inspectExpr(), true, "-fpattern-matching"));
+  EXPECT_TRUE(matchesConditionally("void x() { inspect(42) { 42 => {} }; }", inspectExpr(), true, "-fpattern-matching"));
+  EXPECT_TRUE(matchesConditionally("void x() { int y=0; inspect(42) { y => {} }; }", inspectExpr(), true, "-fpattern-matching"));
   EXPECT_TRUE(matchesConditionally("void x() { }", inspectExpr(), false, "-fpattern-matching"));
-
-  EXPECT_TRUE(matchesConditionally("void x() { struct A{int x;}; A a = {42}; inspect(a) { __:; } }", inspectExpr(), true, "-fpattern-matching"));
-  EXPECT_TRUE(matchesConditionally("void x() { struct A{int x; bool operator==(const A& other) { return x == other.x; } }; A a = {42}; A b = a; inspect(a) { b:; } }", inspectExpr(), true, "-fpattern-matching"));
-}
-
-TEST(PatternMatching, MatchesPattern) {
-  EXPECT_TRUE(matchesConditionally("void x() { inspect(42) { __:; } }", patternStmt(), true, "-fpattern-matching"));
-  EXPECT_TRUE(matchesConditionally("void x() { inspect(42) { 42:; } }", patternStmt(), true, "-fpattern-matching"));
-  EXPECT_TRUE(matchesConditionally("void x() { int y=0; inspect(42) { y:; } }", patternStmt(), true, "-fpattern-matching"));
-  EXPECT_TRUE(matchesConditionally("void x() { }", patternStmt(), false, "-fpattern-matching"));
-
-
-  EXPECT_TRUE(matchesConditionally("void x() { int a=42; inspect(42) { a if(true):; } }", patternStmt(), true, "-fpattern-matching"));
-  EXPECT_TRUE(matchesConditionally("void x() { inspect(42) { 42 if(true):; } }", patternStmt(), true, "-fpattern-matching"));
 }
 
 TEST(ExceptionHandling, SimpleCases) {


### PR DESCRIPTION
inspect parsing was incorrectly inserted between parsing l_square
and a deliberate fallthrough to default. Moved inspect up. Also
fixed some ASTMatcher tests.

Fixes #8