### PR TITLE
[PatternMatching] Add skeleton for Alternative Pattern support

### DIFF
--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -2594,7 +2594,11 @@ enum CXCursorKind {
    */
   CXCursor_StructuredBindingPatternStmt = 290,
 
-  CXCursor_LastStmt = CXCursor_StructuredBindingPatternStmt,
+  /** An alternative pattern statement.
+   */
+  CXCursor_AlternativePatternStmt = 291,
+
+  CXCursor_LastStmt = CXCursor_AlternativePatternStmt,
 
   /**
    * Cursor that represents the translation unit itself.

--- a/clang/include/clang/AST/JSONNodeDumper.h
+++ b/clang/include/clang/AST/JSONNodeDumper.h
@@ -309,6 +309,7 @@ public:
   void VisitIdentifierPatternStmt(const IdentifierPatternStmt *IPS);
   void VisitExpressionPatternStmt(const ExpressionPatternStmt *EPS);
   void VisitStructuredBindingPatternStmt(const StructuredBindingPatternStmt *S);
+  void VisitAlternativePatternStmt(const AlternativePatternStmt *APS);
   void VisitCaseStmt(const CaseStmt *CS);
   void VisitLabelStmt(const LabelStmt *LS);
   void VisitGotoStmt(const GotoStmt *GS);

--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -2250,6 +2250,7 @@ DEF_TRAVERSE_STMT(WildcardPatternStmt, {})
 DEF_TRAVERSE_STMT(IdentifierPatternStmt, {})
 DEF_TRAVERSE_STMT(ExpressionPatternStmt, {})
 DEF_TRAVERSE_STMT(StructuredBindingPatternStmt, {})
+DEF_TRAVERSE_STMT(AlternativePatternStmt, {})
 
 DEF_TRAVERSE_STMT(CXXForRangeStmt, {
   if (!getDerived().shouldVisitImplicitCode()) {

--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -982,6 +982,7 @@ protected:
     friend class IdentifierPatternStmt;
     friend class ExpressionPatternStmt;
     friend class StructuredBindingPatternStmt;
+    friend class AlternativePatternStmt;
 
     unsigned : NumStmtBits;
 
@@ -3646,7 +3647,7 @@ public:
 
 /// Pattern Matching
 ///   PatternStmt is the base class for WildcardPatternStmt,
-///   IdentifierPatternStmt and ExpressionPatternStmt.
+///   IdentifierPatternStmt, ExpressionPatternStmt and AlternativePatternStmt.
 /// Note that the classes below are not in StmtCXX.h to prevent
 /// pulling all of StmtCXX.h into ExprCXX.h for InspectExpr.
 class PatternStmt : public Stmt {
@@ -3706,7 +3707,8 @@ public:
     return T->getStmtClass() == WildcardPatternStmtClass ||
            T->getStmtClass() == IdentifierPatternStmtClass ||
            T->getStmtClass() == ExpressionPatternStmtClass ||
-           T->getStmtClass() == StructuredBindingPatternStmtClass;
+           T->getStmtClass() == StructuredBindingPatternStmtClass ||
+           T->getStmtClass() == AlternativePatternStmtClass;
   }
 };
 
@@ -4230,6 +4232,127 @@ public:
   friend class ASTStmtWriter;
 };
 
+class AlternativePatternStmt final
+    : public PatternStmt,
+      private llvm::TrailingObjects<AlternativePatternStmt, Stmt *> {
+  friend TrailingObjects;
+
+  // AlternativePatternStmt work in progress
+  enum { SubStmtOffset = 0, MatchCondOffset = 1 };
+  enum { NumMandatoryStmtPtr = 2 };
+
+  unsigned matchCondOffset() const { return MatchCondOffset; }
+  unsigned subStmtOffset() const { return SubStmtOffset; }
+  unsigned patternGuardOffset() const {
+    return NumMandatoryStmtPtr;
+  }
+
+  unsigned numTrailingObjects(OverloadToken<Stmt *>) const {
+    return NumMandatoryStmtPtr + hasPatternGuard();
+  }
+
+public:
+  AlternativePatternStmt(SourceLocation PatternLoc, SourceLocation ColonLoc,
+                         Stmt *MatchCond, Stmt *SubStmt, Expr *Guard,
+                         bool ExcludedFromTypeDeduction)
+      : PatternStmt(AlternativePatternStmtClass, PatternLoc, ColonLoc,
+                    ExcludedFromTypeDeduction) {
+    setPatternGuard(Guard);
+    setSubStmt(SubStmt);
+    setMatchCond(MatchCond);
+  }
+
+  /// Build an empty alternative pattern statement.
+  explicit AlternativePatternStmt(EmptyShell Empty, bool HasPatternGuard)
+      : PatternStmt(AlternativePatternStmtClass, Empty) {
+    InspectPatternBits.PatternStmtHasPatternGuard = HasPatternGuard;
+  }
+
+  /// Build an alternative pattern statement.
+  static AlternativePatternStmt *Create(const ASTContext &Ctx,
+                                       SourceLocation PatternLoc,
+                                       SourceLocation ColonLoc,
+                                       Expr *patternGuard,
+                                       bool ExcludedFromTypeDeduction);
+
+  /// Build an empty alternative pattern statement.
+  static AlternativePatternStmt *CreateEmpty(const ASTContext &Ctx,
+                                             bool HasPatternGuard);
+
+  SourceLocation getIdentifierLoc() const { return getPatternLoc(); }
+  void setIdentifierLoc(SourceLocation L) { setPatternLoc(L); }
+
+  Stmt *getMatchCond() {
+    return getTrailingObjects<Stmt *>()[matchCondOffset()];
+  }
+  const Stmt *getMatchCond() const {
+    return getTrailingObjects<Stmt *>()[matchCondOffset()];
+  }
+  void setMatchCond(Stmt *MatchCond) {
+    getTrailingObjects<Stmt *>()[matchCondOffset()] = MatchCond;
+  }
+
+  Stmt *getSubStmt() { return getTrailingObjects<Stmt *>()[subStmtOffset()]; }
+  const Stmt *getSubStmt() const {
+    return getTrailingObjects<Stmt *>()[subStmtOffset()];
+  }
+
+  void setSubStmt(Stmt *S) {
+    getTrailingObjects<Stmt *>()[subStmtOffset()] = S;
+  }
+
+  Expr *getPatternGuard() {
+    assert(hasPatternGuard() && "This pattern has no guard to get!");
+    return reinterpret_cast<Expr *>(
+        getTrailingObjects<Stmt *>()[patternGuardOffset()]);
+  }
+
+  const Expr *getPatternGuard() const {
+    assert(hasPatternGuard() && "This pattern has no guard to get!");
+    return reinterpret_cast<Expr *>(
+        getTrailingObjects<Stmt *>()[patternGuardOffset()]);
+  }
+
+  void setPatternGuard(Expr *Guard) {
+    getTrailingObjects<Stmt *>()[patternGuardOffset()] =
+        reinterpret_cast<Stmt *>(Guard);
+    InspectPatternBits.PatternStmtHasPatternGuard = Guard ? true : false;
+  }
+
+  bool hasPatternGuard() const {
+    return InspectPatternBits.PatternStmtHasPatternGuard;
+  }
+
+  SourceLocation getBeginLoc() const { return getIdentifierLoc(); }
+  SourceLocation getEndLoc() const LLVM_READONLY {
+    // Handle deeply nested identifier pattern statements with iteration instead
+    // of recursion.
+    // FIXME: Is this the right approach? There are no tests for this.
+    const PatternStmt *CS = this;
+    while (const auto *CS2 = dyn_cast<PatternStmt>(CS->getSubStmt()))
+      CS = CS2;
+
+    return CS->getSubStmt()->getEndLoc();
+  }
+
+  static bool classof(const Stmt *T) {
+    return T->getStmtClass() == AlternativePatternStmtClass;
+  }
+
+  // Iterators
+  child_range children() {
+    return child_range(getTrailingObjects<Stmt *>(),
+                       getTrailingObjects<Stmt *>() +
+                           numTrailingObjects(OverloadToken<Stmt *>()));
+  }
+
+  const_child_range children() const {
+    return const_child_range(getTrailingObjects<Stmt *>(),
+                             getTrailingObjects<Stmt *>() +
+                                 numTrailingObjects(OverloadToken<Stmt *>()));
+  }
+};
+
 SourceLocation PatternStmt::getEndLoc() const {
   if (const auto *WP = dyn_cast<WildcardPatternStmt>(this))
     return WP->getEndLoc();
@@ -4239,6 +4362,8 @@ SourceLocation PatternStmt::getEndLoc() const {
     return EP->getEndLoc();
   else if (const auto *SBP = dyn_cast<StructuredBindingPatternStmt>(this))
     return SBP->getEndLoc();
+  else if (const auto *AP = dyn_cast<AlternativePatternStmt>(this))
+    return AP->getEndLoc();
 
   llvm_unreachable("Unknown PatternStmt!");
 }
@@ -4252,6 +4377,8 @@ Stmt *PatternStmt::getSubStmt() {
     return EP->getSubStmt();
   else if (auto *SBP = dyn_cast<StructuredBindingPatternStmt>(this))
     return SBP->getSubStmt();
+  else if (auto *AP = dyn_cast<AlternativePatternStmt>(this))
+    return AP->getSubStmt();
 
   llvm_unreachable("Unknown PatternStmt!");
 }
@@ -4265,6 +4392,8 @@ bool PatternStmt::hasPatternGuard() const {
     return EP->hasPatternGuard();
   else if (auto *SBP = dyn_cast<StructuredBindingPatternStmt>(this))
     return SBP->hasPatternGuard();
+  else if (auto *AP = dyn_cast<AlternativePatternStmt>(this))
+    return AP->hasPatternGuard();
 
   llvm_unreachable("Unknown PatternStmt!");
 }
@@ -4278,6 +4407,8 @@ Expr *PatternStmt::getPatternGuard() {
     return EP->getPatternGuard();
   else if (auto *SBP = dyn_cast<StructuredBindingPatternStmt>(this))
     return SBP->getPatternGuard();
+  else if (auto *AP = dyn_cast<AlternativePatternStmt>(this))
+    return AP->getPatternGuard();
 
   llvm_unreachable("Unknown PatternStmt!");
 }
@@ -4291,6 +4422,8 @@ void PatternStmt::setPatternGuard(Expr *PatternGuard) {
     EP->setPatternGuard(PatternGuard);
   else if (auto *SBP = dyn_cast<StructuredBindingPatternStmt>(this))
     return SBP->setPatternGuard(PatternGuard);
+  else if (auto *AP = dyn_cast<AlternativePatternStmt>(this))
+    return AP->setPatternGuard(PatternGuard);
 
   llvm_unreachable("Unknown PatternStmt!");
 }

--- a/clang/include/clang/AST/TextNodeDumper.h
+++ b/clang/include/clang/AST/TextNodeDumper.h
@@ -229,6 +229,7 @@ public:
   void VisitIdentifierPatternStmt(const IdentifierPatternStmt *Node);
   void VisitExpressionPatternStmt(const ExpressionPatternStmt *Node);
   void VisitStructuredBindingPatternStmt(const StructuredBindingPatternStmt *S);
+  void VisitAlternativePatternStmt(const AlternativePatternStmt *Node);
   void VisitWhileStmt(const WhileStmt *Node);
   void VisitLabelStmt(const LabelStmt *Node);
   void VisitGotoStmt(const GotoStmt *Node);

--- a/clang/include/clang/ASTMatchers/ASTMatchers.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchers.h
@@ -2226,6 +2226,17 @@ extern const internal::VariadicDynCastAllOfMatcher<Stmt,
                                                    StructuredBindingPatternStmt>
     structuredBindingPatternStmt;
 
+/// Matches alternative pattern statements inside inspect expressions.
+///
+/// Given
+/// \code
+///   inspect(a) { b => x(); <T> => y();  __ => z() }
+/// \endcode
+/// AlternativePatternStmt()
+///   matches '<T> =>'.
+extern const internal::VariadicDynCastAllOfMatcher<Stmt, AlternativePatternStmt>
+    alternativePatternStmt;
+
 /// Matches compound statements.
 ///
 /// Example matches '{}' and '{{}}' in 'for (;;) {{}}'

--- a/clang/include/clang/Basic/StmtNodes.td
+++ b/clang/include/clang/Basic/StmtNodes.td
@@ -31,6 +31,7 @@ def WildcardPatternStmt : StmtNode<PatternStmt>;
 def IdentifierPatternStmt : StmtNode<PatternStmt>;
 def ExpressionPatternStmt : StmtNode<PatternStmt>;
 def StructuredBindingPatternStmt : StmtNode<PatternStmt>;
+def AlternativePatternStmt : StmtNode<PatternStmt>;
 
 // Statements that might produce a value (for example, as the last non-null
 // statement in a GNU statement-expression).

--- a/clang/include/clang/Serialization/ASTBitCodes.h
+++ b/clang/include/clang/Serialization/ASTBitCodes.h
@@ -1520,6 +1520,9 @@ namespace serialization {
       /// A StructuredBindingPatternStmt record.
       STMT_STRUCTUREDBINDINGPATTERN,
 
+      /// An AlternativePatternStmt record.
+      STMT_ALTERNATIVEPATTERN,
+
       /// A constant expression context.
       EXPR_CONSTANT,
 

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -555,6 +555,7 @@ namespace clang {
     ExpectedStmt VisitExpressionPatternStmt(ExpressionPatternStmt *S);
     ExpectedStmt
     VisitStructuredBindingPatternStmt(StructuredBindingPatternStmt *S);
+    ExpectedStmt VisitAlternativePatternStmt(AlternativePatternStmt *S);
     ExpectedStmt VisitWhileStmt(WhileStmt *S);
     ExpectedStmt VisitDoStmt(DoStmt *S);
     ExpectedStmt VisitForStmt(ForStmt *S);
@@ -6134,6 +6135,12 @@ ASTNodeImporter::VisitExpressionPatternStmt(ExpressionPatternStmt *S) {
 ExpectedStmt ASTNodeImporter::VisitStructuredBindingPatternStmt(
     StructuredBindingPatternStmt *S) {
   assert(0 && "not implemented");
+  return S;
+}
+
+ExpectedStmt
+ASTNodeImporter::VisitAlternativePatternStmt(AlternativePatternStmt *S) {
+  assert(0 && "Not implemented");
   return S;
 }
 

--- a/clang/lib/AST/JSONNodeDumper.cpp
+++ b/clang/lib/AST/JSONNodeDumper.cpp
@@ -1459,6 +1459,11 @@ void JSONNodeDumper::VisitStructuredBindingPatternStmt(
   assert(0 && "not implemented");
 }
 
+void JSONNodeDumper::VisitAlternativePatternStmt(
+    const AlternativePatternStmt *SS) {
+  assert(0 && "not implemented");
+}
+
 void JSONNodeDumper::VisitLabelStmt(const LabelStmt *LS) {
   JOS.attribute("name", LS->getName());
   JOS.attribute("declId", createPointerRepresentation(LS->getDecl()));

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -246,3 +246,21 @@ void StructuredBindingPatternStmt::setDecompStmt(const ASTContext &Ctx,
                                                  Stmt *S) {
   getTrailingObjects<Stmt *>()[decompDeclOffset()] = S;
 }
+
+AlternativePatternStmt *
+AlternativePatternStmt::CreateEmpty(const ASTContext &Ctx,
+                                    bool HasPatternGuard) {
+  void *Mem = Ctx.Allocate(
+      totalSizeToAlloc<Stmt *>(NumMandatoryStmtPtr + HasPatternGuard),
+      alignof(AlternativePatternStmt));
+  return new (Mem) AlternativePatternStmt(EmptyShell(), HasPatternGuard);
+}
+
+AlternativePatternStmt *
+AlternativePatternStmt::Create(const ASTContext &Ctx,
+                               SourceLocation PatternLoc,
+                               SourceLocation ColonLoc,
+                               Expr *patternGuard,
+                               bool ExcludedFromTypeDeduction) {
+    assert(0 && "not implemented");
+}

--- a/clang/lib/AST/StmtPrinter.cpp
+++ b/clang/lib/AST/StmtPrinter.cpp
@@ -339,6 +339,16 @@ void StmtPrinter::VisitStructuredBindingPatternStmt(
   PrintStmt(Node->getSubStmt(), 0);
 }
 
+void StmtPrinter::VisitAlternativePatternStmt(AlternativePatternStmt *Node) {
+  Indent();
+  PrintExpr(cast<Expr>(Node->getMatchCond()));
+  if (Node->hasPatternGuard()) {
+    PrintExpr(Node->getPatternGuard());
+  }
+  OS << " => ";
+  PrintStmt(Node->getSubStmt(), 0);
+}
+
 void StmtPrinter::VisitWhileStmt(WhileStmt *Node) {
   Indent() << "while (";
   if (const DeclStmt *DS = Node->getConditionVariableDeclStmt())

--- a/clang/lib/AST/StmtProfile.cpp
+++ b/clang/lib/AST/StmtProfile.cpp
@@ -292,6 +292,11 @@ void StmtProfiler::VisitStructuredBindingPatternStmt(
   VisitStmt(S);
 }
 
+void StmtProfiler::VisitAlternativePatternStmt(
+    const AlternativePatternStmt *S) {
+  VisitStmt(S);
+}
+
 void StmtProfiler::VisitWhileStmt(const WhileStmt *S) {
   VisitStmt(S);
   VisitDecl(S->getConditionVariable());

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -704,6 +704,12 @@ void TextNodeDumper::VisitStructuredBindingPatternStmt(
     OS << " has_guard";
 }
 
+void TextNodeDumper::VisitAlternativePatternStmt(
+    const AlternativePatternStmt *Node) {
+  if (Node->hasPatternGuard())
+    OS << " has_guard";
+}
+
 void TextNodeDumper::VisitWhileStmt(const WhileStmt *Node) {
   if (Node->hasVarStorage())
     OS << " has_var";

--- a/clang/lib/ASTMatchers/ASTMatchersInternal.cpp
+++ b/clang/lib/ASTMatchers/ASTMatchersInternal.cpp
@@ -801,6 +801,8 @@ const internal::VariadicDynCastAllOfMatcher<Stmt, ExpressionPatternStmt>
     expressionPatternStmt;
 const internal::VariadicDynCastAllOfMatcher<Stmt, StructuredBindingPatternStmt>
     structuredBindingPatternStmt;
+const internal::VariadicDynCastAllOfMatcher<Stmt, AlternativePatternStmt>
+    alternativePatternStmt;
 const internal::VariadicDynCastAllOfMatcher<Stmt, CompoundStmt> compoundStmt;
 const internal::VariadicDynCastAllOfMatcher<Stmt, CXXCatchStmt> cxxCatchStmt;
 const internal::VariadicDynCastAllOfMatcher<Stmt, CXXTryStmt> cxxTryStmt;

--- a/clang/lib/ASTMatchers/Dynamic/Registry.cpp
+++ b/clang/lib/ASTMatchers/Dynamic/Registry.cpp
@@ -128,6 +128,7 @@ RegistryMaps::RegistryMaps() {
   REGISTER_MATCHER(addrLabelExpr);
   REGISTER_MATCHER(alignOfExpr);
   REGISTER_MATCHER(allOf);
+  REGISTER_MATCHER(alternativePatternStmt);
   REGISTER_MATCHER(anyOf);
   REGISTER_MATCHER(anything);
   REGISTER_MATCHER(argumentCountIs);

--- a/clang/lib/Analysis/CFG.cpp
+++ b/clang/lib/Analysis/CFG.cpp
@@ -626,6 +626,7 @@ private:
   CFGBlock *VisitExpressionPatternStmt(ExpressionPatternStmt *Terminator);
   CFGBlock *
   VisitStructuredBindingPatternStmt(StructuredBindingPatternStmt *Terminator);
+  CFGBlock *VisitAlternativePatternStmt(AlternativePatternStmt *Terminator);
 
   void maybeAddScopeBeginForVarDecl(CFGBlock *B, const VarDecl *VD,
                                     const Stmt *S) {
@@ -2356,6 +2357,9 @@ CFGBlock *CFGBuilder::Visit(Stmt * S, AddStmtChoice asc,
     case Stmt::StructuredBindingPatternStmtClass:
       return VisitStructuredBindingPatternStmt(
           cast<StructuredBindingPatternStmt>(S));
+
+    case Stmt::AlternativePatternStmtClass:
+      return VisitAlternativePatternStmt(cast<AlternativePatternStmt>(S));
   }
 }
 
@@ -4453,6 +4457,11 @@ CFGBlock *CFGBuilder::VisitExpressionPatternStmt(ExpressionPatternStmt *EPS) {
 
 CFGBlock *CFGBuilder::VisitStructuredBindingPatternStmt(
     StructuredBindingPatternStmt *Terminator) {
+  return nullptr;
+}
+
+CFGBlock *
+CFGBuilder::VisitAlternativePatternStmt(AlternativePatternStmt *Terminator) {
   return nullptr;
 }
 

--- a/clang/lib/CodeGen/CGExprCXX.cpp
+++ b/clang/lib/CodeGen/CGExprCXX.cpp
@@ -2293,6 +2293,8 @@ static const char *GetPatternName(const PatternStmt *S) {
     return "pat.exp";
   if (const auto *EPS = dyn_cast<StructuredBindingPatternStmt>(S))
     return "pat.stbind";
+  if (const auto *AP = dyn_cast<AlternativePatternStmt>(S))
+    return "pat.alt";
   llvm_unreachable("unexpected pattern type");
 }
 

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -103,6 +103,7 @@ void CodeGenFunction::EmitStmt(const Stmt *S, ArrayRef<const Attr *> Attrs) {
   case Stmt::IdentifierPatternStmtClass:
   case Stmt::ExpressionPatternStmtClass:
   case Stmt::StructuredBindingPatternStmtClass:
+  case Stmt::AlternativePatternStmtClass:
     llvm_unreachable("should have emitted these statements as simple");
 
 #define STMT(Type, Base)
@@ -392,6 +393,9 @@ bool CodeGenFunction::EmitSimpleStmt(const Stmt *S) {
     break;
   case Stmt::StructuredBindingPatternStmtClass:
     EmitStructuredBindingPatternStmt(cast<StructuredBindingPatternStmt>(*S));
+    break;
+  case Stmt::AlternativePatternStmtClass:
+    EmitAlternativePatternStmt(cast<AlternativePatternStmt>(*S));
     break;
   }
 
@@ -1765,6 +1769,8 @@ static const char *GetPatternName(const PatternStmt *S) {
     return "pat.exp";
   if (const auto *EPS = dyn_cast<StructuredBindingPatternStmt>(S))
     return "pat.stbind";
+  if (const auto *AP = dyn_cast<AlternativePatternStmt>(S))
+    return "pat.alt";
   llvm_unreachable("unexpected pattern type");
 }
 
@@ -1934,6 +1940,11 @@ void CodeGenFunction::EmitStructuredBindingPatternStmt(
 
   // Emit the pattern body
   EmitPatternStmtBody(S);
+}
+
+void CodeGenFunction::EmitAlternativePatternStmt(
+    const AlternativePatternStmt &S) {
+  assert(0 && "not implemented");
 }
 
 static std::string

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -3023,6 +3023,7 @@ public:
   void EmitIdentifierPatternStmt(const IdentifierPatternStmt &S);
   void EmitExpressionPatternStmt(const ExpressionPatternStmt &S);
   void EmitStructuredBindingPatternStmt(const StructuredBindingPatternStmt &S);
+  void EmitAlternativePatternStmt(const AlternativePatternStmt &S);
 
   void EmitAsmStmt(const AsmStmt &S);
 

--- a/clang/lib/CodeGen/CodeGenPGO.cpp
+++ b/clang/lib/CodeGen/CodeGenPGO.cpp
@@ -128,6 +128,7 @@ public:
     IdentifierPatternStmtClass,
     ExpressionPatternStmtClass,
     StructuredBindingPatternStmtClass,
+    AlternativePatternStmtClass,
     // The preceding values are available with PGO_HASH_V2.
 
     // Keep this last.  It's for the static assert that follows.
@@ -288,6 +289,8 @@ struct MapRegionCounters : public RecursiveASTVisitor<MapRegionCounters> {
       return PGOHash::ExpressionPatternStmtClass;
     case Stmt::StructuredBindingPatternStmtClass:
       return PGOHash::StructuredBindingPatternStmtClass;
+    case Stmt::AlternativePatternStmtClass:
+      return PGOHash::AlternativePatternStmtClass;
     case Stmt::IfStmtClass:
       return PGOHash::IfStmt;
     case Stmt::CXXTryStmtClass:

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -2072,6 +2072,7 @@ CheckConstexprFunctionStmt(Sema &SemaRef, const FunctionDecl *Dcl, Stmt *S,
   case Stmt::IdentifierPatternStmtClass:
   case Stmt::ExpressionPatternStmtClass:
   case Stmt::StructuredBindingPatternStmtClass:
+  case Stmt::AlternativePatternStmtClass:
     assert(0 && "Not implemented");
     break;
 

--- a/clang/lib/Sema/SemaExceptionSpec.cpp
+++ b/clang/lib/Sema/SemaExceptionSpec.cpp
@@ -1483,6 +1483,7 @@ CanThrowResult Sema::canThrow(const Stmt *S) {
   case Stmt::IdentifierPatternStmtClass:
   case Stmt::WildcardPatternStmtClass:
   case Stmt::StructuredBindingPatternStmtClass:
+  case Stmt::AlternativePatternStmtClass:
     return canSubStmtsThrow(*this, S);
 
   case Stmt::DeclStmtClass: {

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -8769,6 +8769,8 @@ ExprResult Sema::ActOnFinishInspectExpr(SourceLocation InspectLoc,
       return cast<Expr>(S->getSubStmt())->getType();
     if (auto *S = dyn_cast<StructuredBindingPatternStmt>(PS))
       return cast<Expr>(S->getSubStmt())->getType();
+    if (auto *S = dyn_cast<AlternativePatternStmt>(PS))
+      return cast<Expr>(S->getSubStmt())->getType();
     assert(0 && "Not supposed to get here");
     return QualType();
   };

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -7052,6 +7052,12 @@ StmtResult TreeTransform<Derived>::TransformStructuredBindingPatternStmt(
   return StmtError();
 }
 
+template <typename Derived>
+StmtResult TreeTransform<Derived>::TransformAlternativePatternStmt(
+    AlternativePatternStmt *S) {
+  return StmtError();
+}
+
 template<typename Derived>
 StmtResult
 TreeTransform<Derived>::TransformWhileStmt(WhileStmt *S) {

--- a/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -320,6 +320,10 @@ void ASTStmtReader::VisitStructuredBindingPatternStmt(
   assert(0 && "not implemented");
 }
 
+void ASTStmtReader::VisitAlternativePatternStmt(AlternativePatternStmt *S) {
+  assert(0 && "not implemented");
+}
+
 void ASTStmtReader::VisitWhileStmt(WhileStmt *S) {
   VisitStmt(S);
 
@@ -2762,6 +2766,12 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
 
     case STMT_EXPRESSIONPATTERN:
       S = ExpressionPatternStmt::CreateEmpty(
+          Context,
+          /* HasPatternGuard=*/Record[ASTStmtReader::NumStmtFields]);
+      break;
+
+    case STMT_ALTERNATIVEPATTERN:
+      S = AlternativePatternStmt::CreateEmpty(
           Context,
           /* HasPatternGuard=*/Record[ASTStmtReader::NumStmtFields]);
       break;

--- a/clang/lib/Serialization/ASTWriterStmt.cpp
+++ b/clang/lib/Serialization/ASTWriterStmt.cpp
@@ -243,6 +243,10 @@ void ASTStmtWriter::VisitStructuredBindingPatternStmt(
   assert(0 && "not implemented");
 }
 
+void ASTStmtWriter::VisitAlternativePatternStmt(AlternativePatternStmt *S) {
+  assert(0 && "not implemented");
+}
+
 void ASTStmtWriter::VisitWhileStmt(WhileStmt *S) {
   VisitStmt(S);
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -1323,6 +1323,7 @@ void ExprEngine::Visit(const Stmt *S, ExplodedNode *Pred,
     case Stmt::IdentifierPatternStmtClass:
     case Stmt::WildcardPatternStmtClass:
     case Stmt::StructuredBindingPatternStmtClass:
+    case Stmt::AlternativePatternStmtClass:
     case Expr::MSDependentExistsStmtClass:
       llvm_unreachable("Stmt should not be in analyzer evaluation loop");
     case Stmt::ImplicitValueInitExprClass:

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -5297,6 +5297,8 @@ CXString clang_getCursorKindSpelling(enum CXCursorKind Kind) {
     return cxstring::createRef("ExpressionPatternStmt");
   case CXCursor_StructuredBindingPatternStmt:
     return cxstring::createRef("StructuredBindingPatternStmt");
+  case CXCursor_AlternativePatternStmt:
+    return cxstring::createRef("AlternativePatternStmt");
   case CXCursor_WhileStmt:
       return cxstring::createRef("WhileStmt");
   case CXCursor_DoStmt:

--- a/clang/tools/libclang/CXCursor.cpp
+++ b/clang/tools/libclang/CXCursor.cpp
@@ -168,6 +168,10 @@ CXCursor cxcursor::MakeCXCursor(const Stmt *S, const Decl *Parent,
   case Stmt::StructuredBindingPatternStmtClass:
     K = CXCursor_StructuredBindingPatternStmt;
     break;
+    
+  case Stmt::AlternativePatternStmtClass:
+    K = CXCursor_AlternativePatternStmt;
+    break;
 
   case Stmt::WhileStmtClass:
     K = CXCursor_WhileStmt;


### PR DESCRIPTION
Added AlternativePatternStmt type, along with associated enums and methods in JSON printers, AST parsing etc.

The AlternativePatternStmt is mostly a copy of ExpressionPatternStmt, with minor changes so it is detected as the correct type in `classof()`.