### PR TITLE
Updating SemaCXX / Codegen tests to newer clang

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -84,8 +84,7 @@ def err_typecheck_converted_constant_expression_indirect : Error<
 def err_expr_not_cce : Error<
   "%select{case value|enumerator value|non-type template argument|"
   "array size|explicit specifier argument|noexcept specifier argument|"
-  "call to 'size()'|call to 'data()'}0 is not a constant expression|"
-  "pattern}0 is not a constant expression">;
+  "call to 'size()'|call to 'data()'|pattern}0 is not a constant expression">;
 def ext_cce_narrowing : ExtWarn<
   "%select{case value|enumerator value|non-type template argument|"
   "array size|explicit specifier argument|noexcept specifier argument}0 "

--- a/clang/test/CodeGenCXX/inspect-stbind.cpp
+++ b/clang/test/CodeGenCXX/inspect-stbind.cpp
@@ -34,9 +34,9 @@ int stbind1(s &a) {
       // CHECK: icmp eq i32 {{.*}}, 1
       // CHECK: br i1 {{.*}}, label %patbody, label %pat.wildcard
       // CHECK: patbody:
-      // CHECK: %[[C:.*]] = getelementptr inbounds %struct.s, %struct.s* {{.*}}, i32 0, i32 2
-      // CHECK: load i32, i32* %[[C]], align 4
-      // CEHCK: br label %inspect.epilogue
+      // CHECK: %[[C:.*]] = getelementptr inbounds %struct.s, ptr {{.*}}, i32 0, i32 2
+      // CHECK: load i32, ptr %[[C]], align 4
+      // CHECK: br label %inspect.epilogue
       __ => 0;
   };
 

--- a/clang/test/SemaCXX/inspect.cpp
+++ b/clang/test/SemaCXX/inspect.cpp
@@ -124,10 +124,10 @@ constexpr int Sum(int a = 0, const int &b = 0, const int *c = &z, char d = 0) {
   return a + b + *c + d;
 }
 
-void integral_constants(int x) { // expected-note {{declared here}}
+void integral_constants(int x) { // expected-note 2 {{declared here}}
   const int h = 42;
   struct Y { int a; int b; };
-  const Y y = {2, 3};
+  constexpr Y y = {2, 3};
   Y y2 = {4+x, 3+x}; // expected-note {{declared here}}
   inspect (x) {
     case h => {}
@@ -135,11 +135,11 @@ void integral_constants(int x) { // expected-note {{declared here}}
     case y2.b => {} // expected-error {{expression is not an integral constant expression}}
                     // expected-note@-1 {{read of non-constexpr variable 'y2' is not allowed in a constant expression}}
     case ++x => {} // expected-error {{expression is not an integral constant expression}}
-                   // expected-note@-1 {{a constant expression cannot modify an object that is visible outside that expression}}
+                   //  expected-note@-1 {{function parameter 'x' with unknown value cannot be used in a constant expression}}
     case 0 => {}
     case Sum(3) => {}
     case Sum(x) => {} //  expected-error {{expression is not an integral constant expression}}
-                      //  expected-note@-1 {{read of non-const variable 'x' is not allowed in a constant expression}}
+                      //  expected-note@-1 {{function parameter 'x' with unknown value cannot be used in a constant expression}}
   };
 }
 
@@ -176,7 +176,7 @@ void int_struct(int x) {
   s s1{3,4};
   constexpr s s2{4,5};
   s s3{4,5}; // expected-note {{declared here}}
-  const s s4{4,5};
+  const s s4{4,5}; // expected-note {{declared here}}
   inspect (s1) {
     case s2 => {};
     case s3 => {}; // expected-error {{pattern is not a constant expression}}


### PR DESCRIPTION
Pretty simple fixes for two failing test cases, requiring just updating the test cases themselves to match newer LLVM codegen / clang diagnostic messages.
